### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -20,8 +20,8 @@ getZ	KEYWORD2
 getAngle	KEYWORD2
 setTolerance	KEYWORD2
 setJoints	KEYWORD2
-getBaseAngle    KEYWORD2
-setBaseAngle    KEYWORD2
+getBaseAngle	KEYWORD2
+setBaseAngle	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords