### PR TITLE
Fix rotation matrix typo in _applyAngularConstraints method

### DIFF
--- a/src/FABRIK2D.cpp
+++ b/src/FABRIK2D.cpp
@@ -461,8 +461,8 @@ void Fabrik2D::_applyAngularConstraints(Joint const& parent_joint, Joint const& 
         float cos_angle = cos(angle_diff);
         float sin_angle = sin(angle_diff);
 
-        float new_x = nx * cos_angle - nx * sin_angle;
-        float new_y = nx * sin_angle + nx * cos_angle;
+        float new_x = nx * cos_angle - ny * sin_angle;
+        float new_y = nx * sin_angle + ny * cos_angle;
 
         next_joint.x = joint.x + new_x;
         next_joint.y = joint.y + new_y;


### PR DESCRIPTION
This PR fixes a typo in the _applyAngularConstraints mathod that was broken since commit 7703b29.
The incorrect math caused the rotated vector to be computed without using the ny component, which led to incorrect joint positions.

---

\+ Also according to #55 issue,
I think it is safer to nomalize angle_diff to prevent unintended flips near the ±π boundary.
I just accidentally came across this library while working on building my-first-robot, and since I haven’t tested it yet, I’m not entirely sure about this normalization part.
The author of the issue might be able to test this.

- before (rotation matrix typo fixed)
  ```
    // Adjust the joint position based on the clamped angle
    if (current_angle != clamped_angle) {
        float angle_diff = clamped_angle - current_angle;
        
        // Rotate the next joint around the current joint by the angle difference
        float cos_angle = cos(angle_diff);
        float sin_angle = sin(angle_diff);
        
        float new_x = nx * cos_angle - ny * sin_angle;
        float new_y = nx * sin_angle + ny * cos_angle;
        
        next_joint.x = joint.x + new_x;
        next_joint.y = joint.y + new_y;
    }
  ```

- after (rotation matrix typo fixed + add angle_diff normalization)
  ```
    // Adjust the joint position based on the clamped angle
    if (current_angle != clamped_angle) {
        float angle_diff = clamped_angle - current_angle;
        
        // Normalize to prevent unintended flips
        while (angle_diff >  M_PI) angle_diff -= 2.0f * M_PI;
        while (angle_diff < -M_PI) angle_diff += 2.0f * M_PI;

        // Rotate the next joint around the current joint by the angle difference
        float cos_angle = cos(angle_diff);
        float sin_angle = sin(angle_diff);
        
        float new_x = nx * cos_angle - ny * sin_angle;
        float new_y = nx * sin_angle + ny * cos_angle;
        
        next_joint.x = joint.x + new_x;
        next_joint.y = joint.y + new_y;
    }
  ```